### PR TITLE
name field bug fix, hover scale reduced

### DIFF
--- a/pages/all.js
+++ b/pages/all.js
@@ -16,7 +16,7 @@ const All = ({ books }) => {
             {books.map((item) => {
               return (
                 <Link passHref={true} key={item._id} href={`/product/${item.slug}`}>
-                  <div className="lg:w-1/4 md:w-1/2 p-10 w-full cursor-pointer shadow-lg hover:scale-125 hover:bg-white dark:hover:bg-gray-700 dark:bg-gray-900 dark:shadow-orange-600 duration-500">
+                  <div className="lg:w-1/4 md:w-1/2 p-10 w-full cursor-pointer shadow-lg hover:scale-110 hover:bg-white dark:hover:bg-gray-700 dark:bg-gray-900 dark:shadow-orange-600 duration-500">
                     <a className="block relative rounded overflow-hidden">
                       <img
                         alt="ecommerce"

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -11,8 +11,8 @@ const Contact = () => {
     <form action="https://api.web3forms.com/submit" method='POST' className="mt-10">
     <input type="hidden" name="access_key" value="66619689-10ee-4b96-97ac-c6defa916d61" />
       <div className="grid gap-6 sm:grid-cols-2">
-        <div className="relative z-0">
-          <input type="text" name="name" className="peer block w-full appearance-none border-0 border-b border-gray-500 bg-transparent py-2.5 px-0 text-sm text-gray-900 dark:text-orange-300 focus:border-orange-600 focus:outline-none focus:ring-0" placeholder="" />
+      <div className="relative z-0">
+          <input type="text" name="name" className="peer block w-full appearance-none border-0 border-b border-gray-500 bg-transparent py-2.5 px-0 text-sm text-gray-900 dark:text-orange-300 focus:border-orange-600 focus:outline-none focus:ring-0" placeholder=" " />
           <label className="absolute top-3 -z-10 origin-[0] -translate-y-6 scale-75 transform text-sm text-gray-500 duration-300 peer-placeholder-shown:translate-y-0 peer-placeholder-shown:scale-100 peer-focus:left-0 peer-focus:-translate-y-6 peer-focus:scale-75 peer-focus:text-orange-600 peer-focus:dark:text-orange-500">Your name</label>
         </div>
         <div className="relative z-0">


### PR DESCRIPTION
@NandanVyas review time!

Closes #21 

**Previous Behavior**: 'your name' field of Contact Us page was not scaling like other fields.
![Screenshot (1419)](https://user-images.githubusercontent.com/41839176/196784347-7ea13ffa-35db-4179-bec9-eeff9765011f.png)

**Updated Behavior**: all fields and their animations working normally 
![Screenshot (1417)](https://user-images.githubusercontent.com/41839176/196784649-8da46e8b-0ba1-4d09-baf5-a87062b1dbf5.png)
![Screenshot (1418)](https://user-images.githubusercontent.com/41839176/196784730-12f2a0bc-ea9a-4ebe-b5e7-9110a4ba6401.png)

Also I scaled down the on-hover effect on books' cards under 'All' section to make it more appealing. Will update everywhere required once reviewed.


